### PR TITLE
Fix deprecation notices when parsing API classes with PHP 8.0

### DIFF
--- a/vendor/Luracast/Restler/Routes.php
+++ b/vendor/Luracast/Restler/Routes.php
@@ -133,8 +133,14 @@ class Routes
             }
             foreach ($params as $param) {
                 $children = array();
-                $type =
-                    $param->isArray() ? 'array' : $param->getClass();
+                $reflection_type = $param->getType();
+                if ($reflection_type === null) {
+                    $type = null;
+                } elseif ($reflection_type->isBuiltin()) {
+                    $type = $reflection_type->getName();
+                } else {
+                    $type = new ReflectionClass($reflection_type->getName());
+                }
                 $arguments[$param->getName()] = $position;
                 $defaults[$position] = $param->isDefaultValueAvailable() ?
                     $param->getDefaultValue() : null;


### PR DESCRIPTION
This fixes a few deprecations introduced by PHP 8 [0] that can be seen
when generating the Swagger specification file. This can be seen when
running the SwaggerJsonControllerTest unit tests in the Tuleap codebase.

Part of request #17931: Unit tests should pass with PHP 8.0

[0] https://github.com/php/php-src/blob/php-8.0.0RC3/UPGRADING#L888